### PR TITLE
Updating repo link to 'realtime-exercises'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please file issues and open pull requests here! Thank you! For issues with proje
 
 # Project Files
 
-[Please go here](https://github.com/btholt/realtime-exercises)for the project files.
+[Please go here](https://github.com/btholt/realtime-exercises) for the project files.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please file issues and open pull requests here! Thank you! For issues with proje
 
 # Project Files
 
-[Please go here][project] for the project files.
+[Please go here](https://github.com/btholt/realtime-exercises)for the project files.
 
 # License
 
@@ -33,4 +33,4 @@ Icons made by <a href="https://www.freepik.com" title="Freepik">Freepik</a> from
 
 [fem]: https://frontendmasters.com/
 [course]: https://btholt.github.io/complete-intro-to-realtime
-[project]: https://github.com/btholt/realtime-projects/
+[project]: https://github.com/btholt/realtime-exercises/


### PR DESCRIPTION
As the repo name probably changed from realtime-projects to realtime-exercises, updating readme file to correct link 'https://github.com/btholt/realtime-exercises'